### PR TITLE
Use process.hrtime to calculate the request duration

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ module.exports = function(options) {
   const client = new StatsD(options)
 
   return function *reporter(next) {
-    const start = Date.now()
+    const start = process.hrtime()
     try {
       yield next
     } catch(err) {
@@ -36,7 +36,12 @@ function report(client, metric, ctx, start, err) {
     ? (err.status || 500)
     : (ctx.status || 404);
 
-  const duration = new Date - start;
+  // get duration in milliseconds
+  const diff = process.hrtime(start);
+  const seconds = diff[0];
+  const nanoseconds = diff[1];
+  const duration = (seconds * 1000) + (nanoseconds / 1E6);
+
   let tags = [
     `status_code:${status}`,
     `path:${matchedRoute}`,


### PR DESCRIPTION
The javascript `new Date()` doesn't provide enough resolution under the milliseconds.
This PR change how the time is mesure from an integer to a float with more resolution.
